### PR TITLE
ACM TLS Certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,38 @@ your Terraform state and will henceforth be managed by Terraform.
 9.  Then run `terraform apply` to apply any updates / refresh the Terraform state with the new distribution.
 10.  Optional: you may also want to re-run the `aws cloudfront get-distribution...` command - to compare before / after configuration is as expected.
 
+## Creating and Validating a TLS certificate with ACM
+You can optionally use this module to create and validate a certificate in ACM. The default validation option is DNS.  
+Use the following configuration to create, validate and use a certificate with this module:
+```terraform
+module "example" {
+  source = "github.com/uktrade/terraform-module-cloudfront/cloudfront"
+  args = {
+    ...
+    acm_certificate = {
+      domain_name = the-domain-name-for-the-certificate
+      dns_validation_route53_zone: the-route-53-zone-to-create-the-validation-record
+    }
+  }
+}
+```
+Other parameters can also be provided but `domain_name` is mandatory, and also `dns_validation_route53_zone` when using DNS validation.  
+
+Alternatively, use this configration to specify the ARN of an existing validated certificate:
+```terraform
+module "example" {
+  source = "github.com/uktrade/terraform-module-cloudfront/cloudfront"
+  args = {
+    ...
+    viewer_certificate = {
+      acm_certificate_arn = arn-of-an-existing-validated-certificate
+    }
+  }
+}
+```
+
+Note that a certificate created via this module (first option above) **will be used** by the CloudFront distribution. It's not possible to create a certificate but use a different one (i.e. cannot use both `acm_certificate` and `viewer_certificate.acm_certificate_arn` together to create one certificate but use a different one).
+
 ## Example of Parameter Hierarchy and Precedence
 The table below illustrates how arguments at the 3 levels are applied (note: this table looks much clearer in a Markdown previewer - alignment, colours, etc.).  
 - Here, arguments such as `default_cache_behavior.allowed_methods` have been set at the Environment level (2) - to override the Organisation level (1) - but then do not need setting for each Distribution (3).

--- a/cloudfront/certificate.tf
+++ b/cloudfront/certificate.tf
@@ -1,0 +1,34 @@
+resource "aws_acm_certificate" "cert" {
+  provider = aws.us-east-1
+
+  count = can( var.args.acm_certificate.domain_name ) ? 1 : 0
+  domain_name = var.args.acm_certificate.domain_name
+  subject_alternative_names = try( var.args.acm_certificate.subject_alternative_name, [] )
+  validation_method = try( var.args.acm_certificate.validation_method, "DNS" )
+  key_algorithm = try( var.args.acm_certificate.key_algorithm, "RSA_2048" )
+  tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "validation_domain" {
+  provider = aws.us-east-1
+
+  count = can( var.args.acm_certificate.dns_validation_route53_zone ) ? 1 : 0
+  name = var.args.acm_certificate.dns_validation_route53_zone
+  private_zone = try( var.args.acm_certificate.private_zone, null )
+  vpc_id = try( var.args.acm_certificate.vpc_id, null )
+}
+
+resource "aws_route53_record" "validation_record" {
+  provider = aws.us-east-1
+
+  count = can( var.args.acm_certificate.dns_validation_route53_zone ) ? 1 : 0
+  zone_id = data.aws_route53_zone.validation_domain[0].zone_id
+  name = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
+  type = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
+  records = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
+  ttl = try( var.args.acm_certificate.dns_validation_record_ttl, 300 )
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [ aws.default, aws.us-east-1 ]
+    }
+  }
+}
+
 locals {
 
   defaults = {
@@ -55,6 +64,7 @@ locals {
 
 
 resource "aws_cloudfront_distribution" "standard" {
+  provider = aws.default
 
   enabled = try( var.args.enabled, local.defaults.enabled )
   is_ipv6_enabled = try( var.args.is_ipv6_enabled, local.defaults.is_ipv6_enabled )

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -171,10 +171,16 @@ resource "aws_cloudfront_distribution" "standard" {
   
   viewer_certificate {
     cloudfront_default_certificate = try(
-      var.args.viewer_certificate.cloudfront_default_certificate, # Can specify the default cert here...
-      can( var.args.viewer_certificate.acm_certificate_arn ) ? false : true # ...otherwise set to false if an arn is provided, true otherwise.
+      var.args.viewer_certificate.cloudfront_default_certificate, # Can specify to use the default cert here...
+      can( 
+        try( aws_acm_certificate.cert[0].arn, var.args.viewer_certificate.acm_certificate_arn )
+      ) ? false : true # ...otherwise set to false if a cert was created in this module on arn is specified, true otherwise.
     )
-    acm_certificate_arn = try( var.args.viewer_certificate.acm_certificate_arn, local.defaults.viewer_certificate.acm_certificate_arn )
+    acm_certificate_arn = try(
+      aws_acm_certificate.cert[0].arn, # Use certificate if one was created in this module.
+      var.args.viewer_certificate.acm_certificate_arn, # Or use an explicit ARN, if it's been defined.
+      local.defaults.viewer_certificate.acm_certificate_arn # Otherwise use the certificate from local.default
+    )
     iam_certificate_id = try( var.args.viewer_certificate.iam_certificate_id, local.defaults.viewer_certificate.iam_certificate_id )
     minimum_protocol_version = try( var.args.viewer_certificate.minimum_protocol_version, local.defaults.viewer_certificate.minimum_protocol_version )
     ssl_support_method = try( var.args.viewer_certificate.ssl_support_method, local.defaults.viewer_certificate.ssl_support_method )


### PR DESCRIPTION
Makes the following changes:
- Provides the option to configure `acm_certificate` args to deploy, validate and use a certificate.
- Updates the CloudFront resource `viewer_certificate` block so if a certificate is deployed here, it will be used.
- Adds a providers block so different AWS Regions can be specified.
- Readme updates and examples.