### PR TITLE
Add outputs: CloudFront distribution and certificate

### DIFF
--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_cloudfront_distribution" {
+  value = aws_cloudfront_distribution.standard
+}
+
+output "aws_acm_certificate" {
+  value = aws_acm_certificate.cert
+}


### PR DESCRIPTION
Makes the following changes:
- Adds 2 outputs:
  - `aws_cloudfront_distribution`
  - `aws_acm_certificate`
 
To allow the created resources to be referenced in other resources.