### PR TITLE
S3 Redirect module

### DIFF
--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -3,5 +3,5 @@ output "aws_cloudfront_distribution" {
 }
 
 output "aws_acm_certificate" {
-  value = aws_acm_certificate.cert
+  value = try( aws_acm_certificate.cert[0], null )
 }

--- a/s3-redirect/main.tf
+++ b/s3-redirect/main.tf
@@ -1,0 +1,135 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [ aws.default ]
+    }
+  }
+}
+
+locals {
+  tags = merge(
+    { "Terraform_source_repo" = "terraform-module-cloudfront" },
+    var.tags
+  )
+}
+
+
+resource "aws_s3_bucket" "redirect" {
+  provider = aws.default
+  bucket = var.args.bucket
+  tags = local.tags
+}
+
+resource "aws_s3_bucket_website_configuration" "redirect" {
+  provider = aws.default
+  count = can( try(var.args.redirect_all_requests_to, var.args.routing_rule, var.args.routing_rules) ) ? 1 : 0
+  bucket = aws_s3_bucket.redirect.id
+
+  dynamic "redirect_all_requests_to" {
+    for_each = try( var.args.redirect_all_requests_to, [] )
+    content {
+      host_name = redirect_all_requests_to.value.host_name
+      protocol  = try( redirect_all_requests_to.value.protocol, "https" )
+    }
+  }
+
+  dynamic "index_document" {
+    for_each = try( var.args.index_document, [] )
+    content {
+      suffix = index_document.value.suffix
+    }
+  }
+
+  dynamic "error_document" {
+    for_each = try( var.args.error_document, [] )
+    content {
+      key = error_document.value.key
+    }
+  }
+
+  dynamic "routing_rule" {
+    for_each = try( var.args.routing_rule, [] )
+    content {
+      dynamic condition {
+        for_each = try( routing_rule.value.condition, [] )
+        content {
+          http_error_code_returned_equals = try( condition.value.http_error_code_returned_equals, null )
+          key_prefix_equals = try( condition.value.key_prefix_equals, null )
+        }
+      }
+      dynamic redirect {
+        for_each = try( routing_rule.value.redirect, [] )
+        content {
+          host_name = redirect.value.host_name
+          http_redirect_code = try( redirect.value.http_redirect_code, 301)
+          protocol = try( redirect.value.protocol, "https" )
+          replace_key_prefix_with = try( redirect.value.replace_key_prefix_with, null )
+          replace_key_with = try( redirect.value.replace_key_with, null)
+        }
+      }
+    }
+  }
+
+  routing_rules = try( var.args.routing_rules, null )
+
+}
+
+resource "aws_s3_bucket_public_access_block" "redirect" {
+  provider = aws.default
+  bucket = aws_s3_bucket.redirect.id
+  block_public_acls = try(
+    var.args.aws_s3_bucket_public_access_block.all,
+    var.args.aws_s3_bucket_public_access_block.block_public_acls,
+    true
+  )
+  block_public_policy = try(
+    var.args.aws_s3_bucket_public_access_block.all,
+    var.args.aws_s3_bucket_public_access_block.block_public_policy,
+    true
+  )
+  ignore_public_acls = try(
+    var.args.aws_s3_bucket_public_access_block.all,
+    var.args.aws_s3_bucket_public_access_block.ignore_public_acls,
+    true
+  )
+  restrict_public_buckets = try(
+    var.args.aws_s3_bucket_public_access_block.all,
+    var.args.aws_s3_bucket_public_access_block.restrict_public_buckets,
+    true
+  )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "redirect_apply_sse" {
+  provider = aws.default
+  bucket = aws_s3_bucket.redirect.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "redirect_deny_non_https_access" {
+  provider = aws.default
+  bucket = aws_s3_bucket.redirect.id
+  policy = data.aws_iam_policy_document.redirect_deny_non_https_access.json
+}
+
+data "aws_iam_policy_document" "redirect_deny_non_https_access" {
+   statement {
+    sid = "Deny non-HTTPS access"
+    actions = ["s3:*"]
+    effect = "Deny"
+    resources = ["${aws_s3_bucket.redirect.arn}/*"]
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
+  }
+}

--- a/s3-redirect/outputs.tf
+++ b/s3-redirect/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_s3_bucket" {
+  value = aws_s3_bucket.redirect
+}
+
+output "aws_s3_bucket_website_configuration" {
+  value = try( aws_s3_bucket_website_configuration.redirect[0], null )
+}

--- a/s3-redirect/variables.tf
+++ b/s3-redirect/variables.tf
@@ -1,0 +1,11 @@
+variable "args" {
+  default     = null
+  description = "A map of arguments to apply to the bucket."
+  type        = any
+}
+
+variable "tags" {
+  default     = {}
+  description = "A map of tags to assign to the bucket."
+  type        = map(any)
+}


### PR DESCRIPTION
Makes the following changes:
 - Creates a module for S3 redirection, which creates:
   - the S3 bucket
   - Static website configuration (routing rules, etc.)
   - Public access permissions
   - Encryption
 - Configures outputs which can then be used with the CloudFront module.
 - Updates the Readme with details.
 - Updates the `aws_acm_certificate` output from the CloudFront module so you don't need to specify the `[0]` index when using it.