### PR TITLE
Update ACM Certificate domain validation from zero-index list reference to for_each map.

### DIFF
--- a/cloudfront/certificate.tf
+++ b/cloudfront/certificate.tf
@@ -26,7 +26,7 @@ resource "aws_route53_record" "validation_record" {
   provider = aws.us-east-1
 
   for_each = {
-    for domain_validation_option in aws_acm_certificate.cert[0].domain_validation_options : domain_validation_option.domain_name => {
+    for domain_validation_option in try ( aws_acm_certificate.cert[0].domain_validation_options,[] ) : domain_validation_option.domain_name => {
       name = domain_validation_option.resource_record_name
       type = domain_validation_option.resource_record_type
       record = domain_validation_option.resource_record_value

--- a/cloudfront/certificate.tf
+++ b/cloudfront/certificate.tf
@@ -25,10 +25,18 @@ data "aws_route53_zone" "validation_domain" {
 resource "aws_route53_record" "validation_record" {
   provider = aws.us-east-1
 
-  count = can( var.args.acm_certificate.dns_validation_route53_zone ) ? 1 : 0
+  for_each = {
+    for domain_validation_option in aws_acm_certificate.cert[0].domain_validation_options : domain_validation_option.domain_name => {
+      name = domain_validation_option.resource_record_name
+      type = domain_validation_option.resource_record_type
+      record = domain_validation_option.resource_record_value
+    }
+  }
+
   zone_id = data.aws_route53_zone.validation_domain[0].zone_id
-  name = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_name
-  type = tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_type
-  records = [tolist(aws_acm_certificate.cert[0].domain_validation_options)[0].resource_record_value]
+  name = each.value.name
+  type = each.value.type
+  records = [each.value.record]
   ttl = try( var.args.acm_certificate.dns_validation_record_ttl, 300 )
+  allow_overwrite = true
 }


### PR DESCRIPTION
This resolves the issue where some certificates (those with alternate names) have multiple domain validation options / DNS records and they are not all the same.  
Now we will iterate through all `domain_validation_option` properties, creating Route 53 records for each.  
This uses a similar principle to the one described in the [Terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation).
