### PR TITLE
Create Optional CloudFront Certificate Sub-module

### DIFF
--- a/cloudfront/certificate.tf
+++ b/cloudfront/certificate.tf
@@ -1,42 +1,10 @@
-resource "aws_acm_certificate" "cert" {
-  provider = aws.us-east-1
-
+module "cloudfront_certificate" {
+  providers = {
+    aws.default = aws.us-east-1
+  }
   count = can( var.args.acm_certificate.domain_name ) ? 1 : 0
-  domain_name = var.args.acm_certificate.domain_name
-  subject_alternative_names = try( var.args.acm_certificate.subject_alternative_names, [] )
-  validation_method = try( var.args.acm_certificate.validation_method, "DNS" )
-  key_algorithm = try( var.args.acm_certificate.key_algorithm, "RSA_2048" )
+  source = "./certificate"
+
+  args = var.args
   tags = local.tags
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-data "aws_route53_zone" "validation_domain" {
-  provider = aws.us-east-1
-
-  count = can( var.args.acm_certificate.dns_validation_route53_zone ) ? 1 : 0
-  name = var.args.acm_certificate.dns_validation_route53_zone
-  private_zone = try( var.args.acm_certificate.private_zone, null )
-  vpc_id = try( var.args.acm_certificate.vpc_id, null )
-}
-
-resource "aws_route53_record" "validation_record" {
-  provider = aws.us-east-1
-
-  for_each = {
-    for domain_validation_option in try ( aws_acm_certificate.cert[0].domain_validation_options,[] ) : domain_validation_option.domain_name => {
-      name = domain_validation_option.resource_record_name
-      type = domain_validation_option.resource_record_type
-      record = domain_validation_option.resource_record_value
-    }
-  }
-
-  zone_id = data.aws_route53_zone.validation_domain[0].zone_id
-  name = each.value.name
-  type = each.value.type
-  records = [each.value.record]
-  ttl = try( var.args.acm_certificate.dns_validation_record_ttl, 300 )
-  allow_overwrite = true
 }

--- a/cloudfront/certificate/main.tf
+++ b/cloudfront/certificate/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [ aws.default ]
+    }
+  }
+}
+
+resource "aws_acm_certificate" "cert" {
+  provider = aws.default
+
+  domain_name = var.args.acm_certificate.domain_name
+  subject_alternative_names = try( var.args.acm_certificate.subject_alternative_names, [] )
+  validation_method = try( var.args.acm_certificate.validation_method, "DNS" )
+  key_algorithm = try( var.args.acm_certificate.key_algorithm, "RSA_2048" )
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "validation_domain" {
+  provider = aws.default
+
+  name = var.args.acm_certificate.dns_validation_route53_zone
+  private_zone = try( var.args.acm_certificate.private_zone, null )
+  vpc_id = try( var.args.acm_certificate.vpc_id, null )
+}
+
+resource "aws_route53_record" "validation_record" {
+  provider = aws.default
+
+  for_each = {
+    for domain_validation_option in aws_acm_certificate.cert.domain_validation_options : domain_validation_option.domain_name => {
+      name = domain_validation_option.resource_record_name
+      type = domain_validation_option.resource_record_type
+      record = domain_validation_option.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.validation_domain.zone_id
+  name = each.value.name
+  type = each.value.type
+  records = [each.value.record]
+  ttl = try( var.args.acm_certificate.dns_validation_record_ttl, 300 )
+  allow_overwrite = true
+}

--- a/cloudfront/certificate/outputs.tf
+++ b/cloudfront/certificate/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_acm_certificate" {
+  value = aws_acm_certificate.cert
+}
+
+output "aws_route53_record" {
+  value = aws_route53_record.validation_record
+}

--- a/cloudfront/certificate/variables.tf
+++ b/cloudfront/certificate/variables.tf
@@ -4,12 +4,6 @@ variable "args" {
   type        = any
 }
 
-# variable "defaults" {
-#   default     = null
-#   description = "A default map of arguments to apply to the CloudFront distribution. Takes precedence over module defaults."
-#   type        = any
-# }
-
 variable "tags" {
   default     = {}
   description = "A map of tags to assign to the CloudFront distribution."

--- a/cloudfront/certificate/variables.tf
+++ b/cloudfront/certificate/variables.tf
@@ -1,0 +1,17 @@
+variable "args" {
+  default     = null
+  description = "A map of CloudFront arguments to apply to the distribution. Takes precedence over 'defaults' variable values."
+  type        = any
+}
+
+# variable "defaults" {
+#   default     = null
+#   description = "A default map of arguments to apply to the CloudFront distribution. Takes precedence over module defaults."
+#   type        = any
+# }
+
+variable "tags" {
+  default     = {}
+  description = "A map of tags to assign to the CloudFront distribution."
+  type        = map(any)
+}

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -174,11 +174,11 @@ resource "aws_cloudfront_distribution" "standard" {
     cloudfront_default_certificate = try(
       var.args.viewer_certificate.cloudfront_default_certificate, # Can specify to use the default cert here...
       can( 
-        try( aws_acm_certificate.cert[0].arn, var.args.viewer_certificate.acm_certificate_arn )
+        try( module.cloudfront_certificate[0].aws_acm_certificate.arn, var.args.viewer_certificate.acm_certificate_arn )
       ) ? false : true # ...otherwise set to false if a cert was created in this module on arn is specified, true otherwise.
     )
     acm_certificate_arn = try(
-      aws_acm_certificate.cert[0].arn, # Use certificate if one was created in this module.
+      module.cloudfront_certificate[0].aws_acm_certificate.arn, # Use certificate if one was created via this module.
       var.args.viewer_certificate.acm_certificate_arn, # Or use an explicit ARN, if it's been defined.
       local.defaults.viewer_certificate.acm_certificate_arn # Otherwise use the certificate from local.default
     )

--- a/cloudfront/outputs.tf
+++ b/cloudfront/outputs.tf
@@ -3,5 +3,5 @@ output "aws_cloudfront_distribution" {
 }
 
 output "aws_acm_certificate" {
-  value = try( aws_acm_certificate.cert[0], null )
+  value = try( module.cloudfront_certificate.aws_acm_certificate.cert, null )
 }


### PR DESCRIPTION
Makes the following changes to avoid the issue encountered when using `try` and `for_each` together:
- Moves the `aws_acm_certificate` and `aws_route53_record` resources to a sub-module.
  - _This means the "try" logic (to catch when the certificate is / isn't required) is moved from the `aws_route53_record` `for_each` block up to the module._
- Also updates here the `aws_cloudfront_distribution` resource to use the module outputs / attributes instead of 'local' resource attributes.

---
Resolves this error:
> **_Error: Invalid for_each argument_**
> _The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource._
> _When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values._

This is a workaround which avoids the known issue raised here: https://github.com/hashicorp/terraform/issues/31868
