### PR TITLE
chore: add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @uktrade/webops


### PR DESCRIPTION
This contains a module used in the `terraform-cloudfront` repository in GitLab, so we shouldn't archive this repo. At this time, the best action to take is to add a CODEOWNERS file to the repository.