### PR TITLE
feat: allow `forwarded_values` to be disabled

### DIFF
--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -40,6 +40,7 @@ locals {
       default_ttl               = try(var.defaults.default_cache_behavior.default_ttl, 86400)
       max_ttl                   = try(var.defaults.default_cache_behavior.max_ttl, 31536000)
       cache_policy_id           = try(var.defaults.default_cache_behavior.cache_policy_id, null)
+      origin_request_policy_id  = try(var.defaults.default_cache_behavior.origin_request_policy_id, null)
       field_level_encryption_id = try(var.defaults.default_cache_behavior.field_level_encryption_id, null)
       forwarded_values = {
         enabled                 = try(var.defaults.default_cache_behavior.forwarded_values.enabled, true)
@@ -138,6 +139,7 @@ resource "aws_cloudfront_distribution" "standard" {
     allowed_methods           = try(var.args.default_cache_behavior.allowed_methods, local.defaults.default_cache_behavior.allowed_methods)
     cached_methods            = try(var.args.default_cache_behavior.cached_methods, local.defaults.default_cache_behavior.cached_methods)
     cache_policy_id           = try(var.args.default_cache_behavior.cache_policy_id, local.defaults.default_cache_behavior.cache_policy_id)
+    origin_request_policy_id  = try(var.args.default_cache_behavior.origin_request_policy_id, local.defaults.default_cache_behavior.origin_request_policy_id)
     compress                  = try(var.args.default_cache_behavior.compress, local.defaults.default_cache_behavior.compress)
     default_ttl               = try(var.args.default_cache_behavior.default_ttl, local.defaults.default_cache_behavior.default_ttl)
     field_level_encryption_id = try(var.args.default_cache_behavior.field_level_encryption_id, local.defaults.default_cache_behavior.field_level_encryption_id)

--- a/cloudfront/main.tf
+++ b/cloudfront/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      configuration_aliases = [ aws.default, aws.us-east-1 ]
+      configuration_aliases = [aws.default, aws.us-east-1]
     }
   }
 }
@@ -10,50 +10,51 @@ terraform {
 locals {
 
   defaults = {
-    enabled = try( var.defaults.enabled, true )
-    is_ipv6_enabled = try( var.defaults.is_ipv6_enabled, true )
-    aliases = try( var.defaults.aliases, null )
-    web_acl_id = try( var.defaults.web_acl_id, null )
-    price_class = try( var.defaults.price_class, "PriceClass_All" )
+    enabled         = try(var.defaults.enabled, true)
+    is_ipv6_enabled = try(var.defaults.is_ipv6_enabled, true)
+    aliases         = try(var.defaults.aliases, null)
+    web_acl_id      = try(var.defaults.web_acl_id, null)
+    price_class     = try(var.defaults.price_class, "PriceClass_All")
     origin = {
-      connection_attempts = try( var.defaults.origin.connection_attempts, null )
-      connection_timeout = try( var.defaults.origin.connection_timeout, null )
-      custom_origin_config = try( var.defaults.origin.custom_origin_config, [] ) # Sub-map defaults set in-line
-      custom_header = try( var.defaults.origin.custom_header, [] ) # Sub-map defaults set in-line
+      connection_attempts  = try(var.defaults.origin.connection_attempts, null)
+      connection_timeout   = try(var.defaults.origin.connection_timeout, null)
+      custom_origin_config = try(var.defaults.origin.custom_origin_config, []) # Sub-map defaults set in-line
+      custom_header        = try(var.defaults.origin.custom_header, [])        # Sub-map defaults set in-line
     }
     geo_restriction = {
-      restriction_type = try( var.defaults.geo_restriction.restriction_type, "none" )
-      locations = try( var.defaults.geo_restriction.locations, [] )
+      restriction_type = try(var.defaults.geo_restriction.restriction_type, "none")
+      locations        = try(var.defaults.geo_restriction.locations, [])
     }
     viewer_certificate = {
-      acm_certificate_arn = try( var.defaults.viewer_certificate.acm_certificate_arn, null )
-      iam_certificate_id = try( var.defaults.viewer_certificate.iam_certificate_id, null )
-      minimum_protocol_version = try( var.defaults.viewer_certificate.minimum_protocol_version, "TLSv1" )
-      ssl_support_method = try( var.defaults.viewer_certificate.ssl_support_method, null )
+      acm_certificate_arn      = try(var.defaults.viewer_certificate.acm_certificate_arn, null)
+      iam_certificate_id       = try(var.defaults.viewer_certificate.iam_certificate_id, null)
+      minimum_protocol_version = try(var.defaults.viewer_certificate.minimum_protocol_version, "TLSv1")
+      ssl_support_method       = try(var.defaults.viewer_certificate.ssl_support_method, null)
     }
     default_cache_behavior = {
-      allowed_methods  = try( var.defaults.default_cache_behavior.allowed_methods, ["GET", "HEAD", "DELETE", "POST", "OPTIONS", "PUT", "PATCH"] )
-      cached_methods   = try( var.defaults.default_cache_behavior.cached_methods, ["GET", "HEAD"] )
-      viewer_protocol_policy = try( var.defaults.default_cache_behavior.viewer_protocol_policy, "allow-all" )
-      compress = try( var.defaults.default_cache_behavior.compress, true )
-      min_ttl = try( var.defaults.default_cache_behavior.min_ttl, 0 )
-      default_ttl = try( var.defaults.default_cache_behavior.default_ttl, 86400 )
-      max_ttl = try( var.defaults.default_cache_behavior.max_ttl, 31536000 )
-      cache_policy_id = try( var.defaults.default_cache_behavior.cache_policy_id, null )
-      field_level_encryption_id = try( var.defaults.default_cache_behavior.field_level_encryption_id, null )
+      allowed_methods           = try(var.defaults.default_cache_behavior.allowed_methods, ["GET", "HEAD", "DELETE", "POST", "OPTIONS", "PUT", "PATCH"])
+      cached_methods            = try(var.defaults.default_cache_behavior.cached_methods, ["GET", "HEAD"])
+      viewer_protocol_policy    = try(var.defaults.default_cache_behavior.viewer_protocol_policy, "allow-all")
+      compress                  = try(var.defaults.default_cache_behavior.compress, true)
+      min_ttl                   = try(var.defaults.default_cache_behavior.min_ttl, 0)
+      default_ttl               = try(var.defaults.default_cache_behavior.default_ttl, 86400)
+      max_ttl                   = try(var.defaults.default_cache_behavior.max_ttl, 31536000)
+      cache_policy_id           = try(var.defaults.default_cache_behavior.cache_policy_id, null)
+      field_level_encryption_id = try(var.defaults.default_cache_behavior.field_level_encryption_id, null)
       forwarded_values = {
-        query_string = try( var.defaults.default_cache_behavior.forwarded_values.query_string, true )
-        query_string_cache_keys = try( var.defaults.default_cache_behavior.forwarded_values.query_string_cache_keys, [] )
-        headers = try( var.defaults.default_cache_behavior.forwarded_values.headers, [] )
+        enabled                 = try(var.defaults.default_cache_behavior.forwarded_values.enabled, true)
+        query_string            = try(var.defaults.default_cache_behavior.forwarded_values.query_string, true)
+        query_string_cache_keys = try(var.defaults.default_cache_behavior.forwarded_values.query_string_cache_keys, [])
+        headers                 = try(var.defaults.default_cache_behavior.forwarded_values.headers, [])
         cookies = {
-          forward = try( var.defaults.default_cache_behavior.forwarded_values.cookies.forward, "all" )
-          whitelisted_names = try( var.defaults.default_cache_behavior.forwarded_values.cookies.whitelisted_names, null )
+          forward           = try(var.defaults.default_cache_behavior.forwarded_values.cookies.forward, "all")
+          whitelisted_names = try(var.defaults.default_cache_behavior.forwarded_values.cookies.whitelisted_names, null)
         }
       }
     }
-    logging_config = try ( var.defaults.logging_config, [] ) # Sub-map defaults set in-line
-    origin_group = try ( var.defaults.origin_group, [] ) # Sub-map defaults set in-line
-    custom_error_response = try ( var.defaults.custom_error_response, [] ) # error_code default set in-line
+    logging_config        = try(var.defaults.logging_config, [])        # Sub-map defaults set in-line
+    origin_group          = try(var.defaults.origin_group, [])          # Sub-map defaults set in-line
+    custom_error_response = try(var.defaults.custom_error_response, []) # error_code default set in-line
   }
 
   tags = merge(
@@ -67,11 +68,11 @@ locals {
 resource "aws_cloudfront_distribution" "standard" {
   provider = aws.default
 
-  enabled = try( var.args.enabled, local.defaults.enabled )
-  is_ipv6_enabled = try( var.args.is_ipv6_enabled, local.defaults.is_ipv6_enabled )
-  aliases = try( var.args.aliases, local.defaults.aliases )
-  web_acl_id = try( var.args.web_acl_id, local.defaults.web_acl_id )
-  price_class = try( var.args.price_class, local.defaults.price_class )
+  enabled         = try(var.args.enabled, local.defaults.enabled)
+  is_ipv6_enabled = try(var.args.is_ipv6_enabled, local.defaults.is_ipv6_enabled)
+  aliases         = try(var.args.aliases, local.defaults.aliases)
+  web_acl_id      = try(var.args.web_acl_id, local.defaults.web_acl_id)
+  price_class     = try(var.args.price_class, local.defaults.price_class)
 
   dynamic "origin" { # There must be at least one origin.
     for_each = var.args.origin
@@ -80,18 +81,18 @@ resource "aws_cloudfront_distribution" "standard" {
       origin_id = try( # If no ID is specified, use the domain name as the ID. No defaults here.
         origin.value.origin_id,
         origin.value.domain_name
-      ) 
-      connection_attempts = try( origin.value.connection_attempts, local.defaults.origin.connection_attempts )
-      connection_timeout = try( origin.value.connection_timeout, local.defaults.origin.connection_timeout )
-      dynamic "custom_header" { 
-        for_each = can( origin.value.custom_header ) ? origin.value.custom_header : local.defaults.origin.custom_header
+      )
+      connection_attempts = try(origin.value.connection_attempts, local.defaults.origin.connection_attempts)
+      connection_timeout  = try(origin.value.connection_timeout, local.defaults.origin.connection_timeout)
+      dynamic "custom_header" {
+        for_each = can(origin.value.custom_header) ? origin.value.custom_header : local.defaults.origin.custom_header
         content {
-          name = custom_header.value.name
+          name  = custom_header.value.name
           value = custom_header.value.value
         }
       }
       dynamic "custom_origin_config" {
-        for_each = can( origin.value.custom_origin_config ) ? origin.value.custom_origin_config : local.defaults.origin.custom_origin_config
+        for_each = can(origin.value.custom_origin_config) ? origin.value.custom_origin_config : local.defaults.origin.custom_origin_config
         content {
           http_port = try(
             custom_origin_config.value.http_port,
@@ -111,7 +112,7 @@ resource "aws_cloudfront_distribution" "standard" {
           origin_ssl_protocols = try(
             custom_origin_config.value.origin_ssl_protocols,
             local.defaults.origin.custom_origin_config.origin_ssl_protocols,
-            ["TLSv1","TLSv1.1","TLSv1.2"]
+            ["TLSv1", "TLSv1.1", "TLSv1.2"]
           )
           origin_keepalive_timeout = try(
             custom_origin_config.value.origin_keepalive_timeout,
@@ -134,68 +135,73 @@ resource "aws_cloudfront_distribution" "standard" {
       var.args.origin[0].origin_id,
       var.args.origin[0].domain_name
     )
-    allowed_methods = try( var.args.default_cache_behavior.allowed_methods, local.defaults.default_cache_behavior.allowed_methods )
-    cached_methods = try( var.args.default_cache_behavior.cached_methods, local.defaults.default_cache_behavior.cached_methods )
-    cache_policy_id = try( var.args.default_cache_behavior.cache_policy_id, local.defaults.default_cache_behavior.cache_policy_id )
-    compress = try( var.args.default_cache_behavior.compress, local.defaults.default_cache_behavior.compress )
-    default_ttl = try( var.args.default_cache_behavior.default_ttl, local.defaults.default_cache_behavior.default_ttl )
-    field_level_encryption_id = try( var.args.default_cache_behavior.field_level_encryption_id, local.defaults.default_cache_behavior.field_level_encryption_id )
-    max_ttl = try( var.args.default_cache_behavior.max_ttl, local.defaults.default_cache_behavior.max_ttl )
-    min_ttl = try( var.args.default_cache_behavior.min_ttl, local.defaults.default_cache_behavior.min_ttl )
-    viewer_protocol_policy = try( var.args.default_cache_behavior.viewer_protocol_policy, local.defaults.default_cache_behavior.viewer_protocol_policy )
+    allowed_methods           = try(var.args.default_cache_behavior.allowed_methods, local.defaults.default_cache_behavior.allowed_methods)
+    cached_methods            = try(var.args.default_cache_behavior.cached_methods, local.defaults.default_cache_behavior.cached_methods)
+    cache_policy_id           = try(var.args.default_cache_behavior.cache_policy_id, local.defaults.default_cache_behavior.cache_policy_id)
+    compress                  = try(var.args.default_cache_behavior.compress, local.defaults.default_cache_behavior.compress)
+    default_ttl               = try(var.args.default_cache_behavior.default_ttl, local.defaults.default_cache_behavior.default_ttl)
+    field_level_encryption_id = try(var.args.default_cache_behavior.field_level_encryption_id, local.defaults.default_cache_behavior.field_level_encryption_id)
+    max_ttl                   = try(var.args.default_cache_behavior.max_ttl, local.defaults.default_cache_behavior.max_ttl)
+    min_ttl                   = try(var.args.default_cache_behavior.min_ttl, local.defaults.default_cache_behavior.min_ttl)
+    viewer_protocol_policy    = try(var.args.default_cache_behavior.viewer_protocol_policy, local.defaults.default_cache_behavior.viewer_protocol_policy)
 
-    forwarded_values {
-      query_string = try(
-        var.args.default_cache_behavior.forwarded_values.query_string,
-        local.defaults.default_cache_behavior.forwarded_values.query_string
-      )
-      query_string_cache_keys = try(
-        var.args.default_cache_behavior.forwarded_values.query_string_cache_keys,
-        local.defaults.default_cache_behavior.forwarded_values.query_string_cache_keys
-      )
-      headers = try(
-        var.args.default_cache_behavior.forwarded_values.headers,
-        local.defaults.default_cache_behavior.forwarded_values.headers
-      )
-      cookies {
-        forward = try(
-          var.args.default_cache_behavior.forwarded_values.cookies.forward,
-          local.defaults.default_cache_behavior.forwarded_values.cookies.forward
+    dynamic "forwarded_values" {
+      for_each = try(var.args.default_cache_behavior.forwarded_values.enabled, local.defaults.default_cache_behavior.forwarded_values.enabled) ? [1] : []
+
+      content {
+        query_string = try(
+          var.args.default_cache_behavior.forwarded_values.query_string,
+          local.defaults.default_cache_behavior.forwarded_values.query_string
         )
-        whitelisted_names = try(
-          var.args.default_cache_behavior.forwarded_values.cookies.whitelisted_names,
-          local.defaults.default_cache_behavior.forwarded_values.cookies.whitelisted_names
+        query_string_cache_keys = try(
+          var.args.default_cache_behavior.forwarded_values.query_string_cache_keys,
+          local.defaults.default_cache_behavior.forwarded_values.query_string_cache_keys
         )
+        headers = try(
+          var.args.default_cache_behavior.forwarded_values.headers,
+          local.defaults.default_cache_behavior.forwarded_values.headers
+        )
+        cookies {
+          forward = try(
+            var.args.default_cache_behavior.forwarded_values.cookies.forward,
+            local.defaults.default_cache_behavior.forwarded_values.cookies.forward
+          )
+          whitelisted_names = try(
+            var.args.default_cache_behavior.forwarded_values.cookies.whitelisted_names,
+            local.defaults.default_cache_behavior.forwarded_values.cookies.whitelisted_names
+          )
+        }
+
       }
     }
   }
-  
+
   viewer_certificate {
     cloudfront_default_certificate = try(
       var.args.viewer_certificate.cloudfront_default_certificate, # Can specify to use the default cert here...
-      can( 
-        try( module.cloudfront_certificate[0].aws_acm_certificate.arn, var.args.viewer_certificate.acm_certificate_arn )
+      can(
+        try(module.cloudfront_certificate[0].aws_acm_certificate.arn, var.args.viewer_certificate.acm_certificate_arn)
       ) ? false : true # ...otherwise set to false if a cert was created in this module on arn is specified, true otherwise.
     )
     acm_certificate_arn = try(
       module.cloudfront_certificate[0].aws_acm_certificate.arn, # Use certificate if one was created via this module.
-      var.args.viewer_certificate.acm_certificate_arn, # Or use an explicit ARN, if it's been defined.
-      local.defaults.viewer_certificate.acm_certificate_arn # Otherwise use the certificate from local.default
+      var.args.viewer_certificate.acm_certificate_arn,          # Or use an explicit ARN, if it's been defined.
+      local.defaults.viewer_certificate.acm_certificate_arn     # Otherwise use the certificate from local.default
     )
-    iam_certificate_id = try( var.args.viewer_certificate.iam_certificate_id, local.defaults.viewer_certificate.iam_certificate_id )
-    minimum_protocol_version = try( var.args.viewer_certificate.minimum_protocol_version, local.defaults.viewer_certificate.minimum_protocol_version )
-    ssl_support_method = try( var.args.viewer_certificate.ssl_support_method, local.defaults.viewer_certificate.ssl_support_method )
+    iam_certificate_id       = try(var.args.viewer_certificate.iam_certificate_id, local.defaults.viewer_certificate.iam_certificate_id)
+    minimum_protocol_version = try(var.args.viewer_certificate.minimum_protocol_version, local.defaults.viewer_certificate.minimum_protocol_version)
+    ssl_support_method       = try(var.args.viewer_certificate.ssl_support_method, local.defaults.viewer_certificate.ssl_support_method)
   }
 
   restrictions {
     geo_restriction {
-      restriction_type = try( var.args.geo_restriction.restriction_type, local.defaults.geo_restriction.restriction_type )
-      locations = try( var.args.geo_restriction.locations, local.defaults.geo_restriction.locations )
+      restriction_type = try(var.args.geo_restriction.restriction_type, local.defaults.geo_restriction.restriction_type)
+      locations        = try(var.args.geo_restriction.locations, local.defaults.geo_restriction.locations)
     }
   }
 
   dynamic "logging_config" {
-    for_each = can( var.args.logging_config ) ? var.args.logging_config : local.defaults.logging_config
+    for_each = can(var.args.logging_config) ? var.args.logging_config : local.defaults.logging_config
     content {
       bucket = try(
         logging_config.value.bucket,
@@ -215,7 +221,7 @@ resource "aws_cloudfront_distribution" "standard" {
   }
 
   dynamic "origin_group" {
-    for_each = can( var.args.origin_group ) ? var.args.origin_group : local.defaults.origin_group
+    for_each = can(var.args.origin_group) ? var.args.origin_group : local.defaults.origin_group
     content {
       origin_id = origin_group.value.origin_id
       failover_criteria {
@@ -235,12 +241,12 @@ resource "aws_cloudfront_distribution" "standard" {
   }
 
   dynamic "custom_error_response" {
-    for_each = can( var.args.custom_error_response ) ? var.args.custom_error_response : local.defaults.custom_error_response
+    for_each = can(var.args.custom_error_response) ? var.args.custom_error_response : local.defaults.custom_error_response
     content {
-      error_code = try( custom_error_response.value.error_code, 500 )
-      error_caching_min_ttl = try( custom_error_response.value.error_caching_min_ttl, null )
-      response_code = try( custom_error_response.value.response_code, null )
-      response_page_path = try( custom_error_response.value.response_page_path, null )
+      error_code            = try(custom_error_response.value.error_code, 500)
+      error_caching_min_ttl = try(custom_error_response.value.error_caching_min_ttl, null)
+      response_code         = try(custom_error_response.value.response_code, null)
+      response_page_path    = try(custom_error_response.value.response_page_path, null)
     }
   }
 


### PR DESCRIPTION
The `forwarded_values` block has been deprecated, and the use of `cache_policy_id` is preferred.

This has been tested, no changes are reported when applying the Terraform in the uktrade/terraform-cloudfront repository except for distribution attempting to disable the block.

My editor has also auto run a `terraform fmt` against, hence why there appears to be more change then there really is.

The main change starts at line 150 in `cloudfront/main.tf`.